### PR TITLE
Downgrade Nvidia Cuda and fix Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    ignore:
+      - dependency-name: "nvidia/cuda"
+        update-types: [
+          "version-update:semver-major",
+          "version-update:semver-minor"
+        ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-base-ubuntu20.04
+FROM nvidia/cuda:11.7.1-base-ubuntu20.04
 COPY rootfs /
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- Downgrade Nvidia Cuda to 11.7 to be compatible with our server
- Fix Dependabot by ignoring major and minor versions